### PR TITLE
Use clojure / cljs.main to build ClojureScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build:clj": "java -cp src/clj/cljs.jar:src/clj/src clojure.main src/clj/build.clj",
+    "build:clj": "cd src/clj && clojure -m cljs.main -d out -o test.js -O simple -t node -c clj.core",
     "build:kotlin": "kotlinc-js -output src/kotlin/test.js -module-kind commonjs src/kotlin/test.kt",
     "build:go": "~/go/bin/gopherjs build src/go/test.go -o src/go/test.js",
     "build:rkt": "racks -t babel -d src/racket/out src/racket/test.rkt",

--- a/src/clj/build.clj
+++ b/src/clj/build.clj
@@ -1,8 +1,0 @@
-(require 'cljs.build.api)
-
-(cljs.build.api/build "src"
-  {:main 'clj.core
-   :output-dir "src/clj/out"
-   :output-to "src/clj/test.js"
-   :optimizations :simple
-   :target :nodejs})

--- a/src/clj/deps.edn
+++ b/src/clj/deps.edn
@@ -1,0 +1,1 @@
+{:deps {org.clojure/clojurescript {:mvn/version "1.10.238"}}}


### PR DESCRIPTION
Pros:

- No need to build a different `cljs.jar` to try a different version of ClojureScript
- Can easily point `deps.edn` at a `:local/root` during dev to check for improvements / regressions
- Likewise, can point `deps.edn` at a GitHub url/SHA

Cons:

- Users need `clojure` installed
- Only works with ClojureScript 1.10.238 or later (or perhaps any of the 1.10 betas that supported `cljs.main`)